### PR TITLE
Update query to deal with site_stats sharding

### DIFF
--- a/pagecounts.php
+++ b/pagecounts.php
@@ -32,7 +32,7 @@ function getCounts( $wiki ) {
     global $user, $password;
 
     $db = new mysqli( "$wiki.labsdb", $user, $password, "{$wiki}_p" );
-    $sql = 'SELECT ss_total_pages, ss_good_articles FROM site_stats LIMIT 1';
+    $sql = 'SELECT SUM(ss_total_pages) AS ss_total_pages, SUM(ss_good_articles) as ss_good_articles FROM site_stats';
     $res = $db->query( $sql );
     $row = $res->fetch_object();
     $db->close();


### PR DESCRIPTION
As described in https://phabricator.wikimedia.org/T306589, site_stats can now have more than one row, and so it's necessary to sum over all the rows. The change is backward-compatible.